### PR TITLE
[Issue-25] Cache popups, that have already been brought to front

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -64,6 +64,7 @@ class AfterEffectsEngine(sgtk.platform.Engine):
     _AFX_PID = None
     _POPUP_CACHE = None
     _AFX_WIN32_DIALOG_WINDOW_CLASS = "#32770" # the windows window class name used by After Effects for modal dialogs
+    __WIN32_GW_CHILD = 5
     _CONTEXT_CACHE_KEY = "aftereffects_context_cache"
 
     _HAS_CHECKED_CONTEXT_POST_LAUNCH = False
@@ -1178,8 +1179,11 @@ class AfterEffectsEngine(sgtk.platform.Engine):
 
             # we build a dict that maps the hwnd longs to the current hwnd pointer
             all_hwnds = {}
+            GetWindow = self.__tk_aftereffects.win_32_api.ctypes.windll.user32.GetWindow
             for hwnd in hwnds:
-                all_hwnds[self.__tk_aftereffects.win_32_api.ctypes.windll.user32.GetWindow(hwnd, 5)] = hwnd
+                # GetWindow with GW_CHILD is used to get the hwnd long that identifies the child window
+                # at the top of the Z order, of the specified parent window pointer.
+                all_hwnds[GetWindow(hwnd, self.__WIN32_GW_CHILD)] = hwnd
 
             # by comparing the cached hwnd longs with the current list of hwnd longs,
             # we find out which hwnds are actually pointing to new (unraised) dialogs.


### PR DESCRIPTION
This Bugfix solves the following issue:
The __check_for_popups method was called by a QTimer every second. Every time a dialog  (Error-, Info-, Warning- or Option-Window) was popping up inside After Effects, this dialog window should be raised above the Python-windows created by the engine.
Although the current implementation worked, it was raising the window every time, the QTimer triggered this method, breaking drop-down and line-edit widgets in modal dialogs of After Effects.

The solution is to cache, which windows, have already been raised to the front while still being aware of new popups.

If the method finds a (new) dialog, it will raise it and then cache ALL open dialogs at the time of raising. Next time the method is triggered, the new list will be compared against the old list and recache if there are additional dialogs or clean the cache in case all dialogs were closed.