### PR TITLE
SG-14250: Disables window closing during loader2 actions to prevent crashing

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1377,6 +1377,13 @@ class AfterEffectsEngine(sgtk.platform.Engine):
         # make sure the window raised so it doesn't
         # appear behind the main After Effects window
         self.logger.debug("Showing dialog: %s" % (title,))
+
+        # Adding this window flag will ensure that our dialogs won't be
+        # tabbed together into a single window on OSX.
+        if sys.platform == "darwin":
+            from sgtk.platform.qt import QtCore
+            dialog.setWindowFlags(dialog.windowFlags() | QtCore.Qt.CustomizeWindowHint)
+
         dialog.show()
         dialog.raise_()
         dialog.activateWindow()


### PR DESCRIPTION
We've always had stability issues with our integrations in Adobe CC products (PS/AE) when a dialog is forcibly closed during a long-running operation in the application. This fix disables the ability to close the loader2 dialog while an action is in progress.

This also tweaks the window flags of dialogs spawned by the integration to ensure that sgtk apps will launch in their own windows instead of being tabbed together into a single window on OSX.