### PR TITLE
Sg 14346 add open file on startup support

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -228,6 +228,16 @@ class AfterEffectsEngine(sgtk.platform.Engine):
             dict(),
         )
 
+        # Normally the bootstrap logic would handle the file open, but since the bootstrap logic is handled by
+        # the adobe framework, and is generic, we should handle it here.
+        file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
+
+        if file_to_open:
+            # open the specified script
+            self.adobe.app.open(self.adobe.File(file_to_open))
+            # clear the environment variable after loading so that it doesn't get reopened on an engine restart.
+            del os.environ["SGTK_FILE_TO_OPEN"]
+
     def destroy_engine(self):
         """
         Called when the engine should tear down itself and all its apps.

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -340,15 +340,22 @@ class AfterEffectsUploadVersionPlugin(HookBaseClass):
 
     def __render_movie_from_sequence(self, sequence_path, queue_item, mov_output_module_template):
 
+        self.logger.debug("Sequence path: %s" % sequence_path)
+
         for first_frame, _ in self.parent.engine.get_render_files(sequence_path, queue_item):
             break
 
+        self.logger.debug("First frame: %s" % first_frame)
+        self.logger.debug("Importing footage...")
         # import the footage and add it to the render queue
         new_items = self.parent.engine.import_filepath(first_frame)
+        self.logger.debug("Imported footage items: %s" % new_items)
         for new_item in new_items:
             break
         else:
             return ''
+
+        self.logger.debug("Adding new comp: %s" % new_item)
         new_cmp_item = self.parent.engine.adobe.app.project.items.addComp(
             new_item.name,
             new_item.width,
@@ -361,6 +368,7 @@ class AfterEffectsUploadVersionPlugin(HookBaseClass):
         for new_item in new_items:
             new_cmp_item.layers.add(new_item)
 
+        self.logger.debug("Adding the comp to the render queue: %s" % new_cmp_item)
         temp_item = self.parent.engine.adobe.app.project.renderQueue.items.add(new_cmp_item)
         output_path = self.__render_to_temp_location(temp_item, mov_output_module_template)
 
@@ -382,12 +390,16 @@ class AfterEffectsUploadVersionPlugin(HookBaseClass):
         allocate_file = tempfile.NamedTemporaryFile(suffix=ext)
         allocate_file.close()
 
+        self.logger.debug("Setting temporary location to: %s" % allocate_file.name)
+
         render_file = self.parent.engine.adobe.File(allocate_file.name)
         output_module.file = render_file
 
+        self.logger.debug("Rendering the queue item")
         # render
         render_state = self.parent.engine.render_queue_item(temporary_queue_item)
 
+        self.logger.debug("Render state: %s" % render_state)
         # return the render file path or an empty string
         if render_state:
             return allocate_file.name

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -368,7 +368,7 @@ class AfterEffectsUploadVersionPlugin(HookBaseClass):
         for new_item in new_items:
             new_cmp_item.layers.add(new_item)
 
-        self.logger.debug("Adding the comp to the render queue: %s" % new_cmp_item)
+        self.logger.debug("Adding the comp %s to the render queue" % new_cmp_item)
         temp_item = self.parent.engine.adobe.app.project.renderQueue.items.add(new_cmp_item)
         output_path = self.__render_to_temp_location(temp_item, mov_output_module_template)
 
@@ -389,7 +389,6 @@ class AfterEffectsUploadVersionPlugin(HookBaseClass):
 
         allocate_file = tempfile.NamedTemporaryFile(suffix=ext)
         allocate_file.close()
-
         self.logger.debug("Setting temporary location to: %s" % allocate_file.name)
 
         render_file = self.parent.engine.adobe.File(allocate_file.name)

--- a/startup.py
+++ b/startup.py
@@ -75,6 +75,10 @@ class AfterEffectsLauncher(SoftwareLauncher):
         std_env = self.get_standard_plugin_environment()
         required_env.update(std_env)
 
+        # populate the file to open env.
+        if file_to_open:
+            required_env["SGTK_FILE_TO_OPEN"] = file_to_open
+
         return LaunchInformation(exec_path, args, required_env)
 
     def scan_software(self):


### PR DESCRIPTION
This adds functionality to enable the After Effects engine to accept a file on start up and open it once After Effects is launched.

Associated with [this PR.](https://github.com/shotgunsoftware/tk-shotgun-launchpublish/pull/7)

Since the bootstrap logic is generic (via the adobe framework) I opted to put the open logic inside the engine post init method. Not sure if there is a more appropriate place to do this instead?

Similar to:
https://github.com/shotgunsoftware/tk-photoshopcc/pull/68