### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-aftereffects?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=70&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/engine.py
+++ b/engine.py
@@ -72,7 +72,7 @@ class AfterEffectsEngine(sgtk.platform.Engine):
 
     __CC_VERSION_MAPPING = {12: "2015", 13: "2016", 14: "2017", 15: "2018", 16: "2019"}
 
-    __IS_SEQUENCE_REGEX = re.compile(u"[\[]?([#@]+|[%]0\dd)[\]]?")
+    __IS_SEQUENCE_REGEX = re.compile("[\[]?([#@]+|[%]0\dd)[\]]?")
 
     ############################################################################
     # context changing
@@ -218,7 +218,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
         self.logger.debug("Single document found, clearing stored context cache.")
 
         self.__settings_manager.store(
-            self._CONTEXT_CACHE_KEY, dict(),
+            self._CONTEXT_CACHE_KEY,
+            dict(),
         )
 
         # Normally the bootstrap logic would handle the file open, but since the bootstrap logic is handled by
@@ -300,7 +301,9 @@ class AfterEffectsEngine(sgtk.platform.Engine):
         properties = properties or dict()
         properties["uid"] = self.__get_command_uid()
         return super(AfterEffectsEngine, self).register_command(
-            name, callback, properties,
+            name,
+            callback,
+            properties,
         )
 
     @property
@@ -683,7 +686,10 @@ class AfterEffectsEngine(sgtk.platform.Engine):
 
         # We need to get all files that match the pattern from disk so that we
         # can determine what the min and max frame number is.
-        glob_path = "%s%s" % (re.sub(frame_pattern, r"\1*", root), ext,)
+        glob_path = "%s%s" % (
+            re.sub(frame_pattern, r"\1*", root),
+            ext,
+        )
         files = glob.glob(glob_path)
 
         # Our pattern from above matches against the file root, so we need
@@ -841,7 +847,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
             else:
                 try:
                     context = self.sgtk.context_from_path(
-                        active_document_path, previous_context=self.context,
+                        active_document_path,
+                        previous_context=self.context,
                     )
                     self.__add_to_context_cache(active_document_path, context)
                 except Exception:
@@ -857,7 +864,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
                     # SGTK control.
                     if self._PROJECT_CONTEXT is None:
                         self._PROJECT_CONTEXT = sgtk.Context(
-                            tk=self.context.sgtk, project=self.context.project,
+                            tk=self.context.sgtk,
+                            project=self.context.project,
                         )
 
                     context = self._PROJECT_CONTEXT
@@ -1254,8 +1262,10 @@ class AfterEffectsEngine(sgtk.platform.Engine):
             # needed to turn a Qt5 WId into an HWND is not exposed in PySide2,
             # so we can't do what we did below for Qt4.
             if QtCore.__version__.startswith("4."):
-                proxy_win_hwnd = self.__tk_aftereffects.win_32_api.qwidget_winid_to_hwnd(
-                    win32_proxy_win.winId(),
+                proxy_win_hwnd = (
+                    self.__tk_aftereffects.win_32_api.qwidget_winid_to_hwnd(
+                        win32_proxy_win.winId(),
+                    )
                 )
             else:
                 # With PySide2, we're required to look up our proxy parent
@@ -1269,10 +1279,12 @@ class AfterEffectsEngine(sgtk.platform.Engine):
                 win32_proxy_win.show()
 
                 try:
-                    proxy_win_hwnd_found = self.__tk_aftereffects.win_32_api.find_windows(
-                        stop_if_found=True,
-                        class_name="Qt5QWindowIcon",
-                        process_id=os.getpid(),
+                    proxy_win_hwnd_found = (
+                        self.__tk_aftereffects.win_32_api.find_windows(
+                            stop_if_found=True,
+                            class_name="Qt5QWindowIcon",
+                            process_id=os.getpid(),
+                        )
                     )
                 finally:
                     win32_proxy_win.hide()
@@ -1300,7 +1312,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
             # dialogs to notify the After Effects application window when they're
             # opened or closed, so we'll disable that behavior.
             win_ex_style = self.__tk_aftereffects.win_32_api.GetWindowLong(
-                proxy_win_hwnd, self.__tk_aftereffects.win_32_api.GWL_EXSTYLE,
+                proxy_win_hwnd,
+                self.__tk_aftereffects.win_32_api.GWL_EXSTYLE,
             )
 
             self.__tk_aftereffects.win_32_api.SetWindowLong(
@@ -1625,7 +1638,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
         # force the Jump to Shotgun and Jump to Filesystem commands onto the
         # front of the list to match other integrations.
         context_menu_cmds = jump_commands + sorted(
-            context_menu_cmds, key=lambda d: d["display_name"],
+            context_menu_cmds,
+            key=lambda d: d["display_name"],
         )
 
         # ---- populate the state structure to hand over to adobe
@@ -1665,13 +1679,17 @@ class AfterEffectsEngine(sgtk.platform.Engine):
 
             from sgtk.platform.qt import QtCore
 
-            timer = QtCore.QTimer(parent=QtCore.QCoreApplication.instance(),)
+            timer = QtCore.QTimer(
+                parent=QtCore.QCoreApplication.instance(),
+            )
 
             timer.timeout.connect(self._check_connection)
             timer.timeout.connect(self.__check_for_popups)
 
             # The class variable is in seconds, so multiply to get milliseconds.
-            timer.start(self.SHOTGUN_ADOBE_HEARTBEAT_INTERVAL * 1000.0,)
+            timer.start(
+                self.SHOTGUN_ADOBE_HEARTBEAT_INTERVAL * 1000.0,
+            )
 
             self._CHECK_CONNECTION_TIMER = timer
             self.logger.debug("Connection timer created and started.")
@@ -1862,7 +1880,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
                     thumb_path = "../images/default_Entity_thumb_dark.png"
 
                 data = dict(
-                    thumb_path=thumb_path, url=self.get_entity_url(context_entity),
+                    thumb_path=thumb_path,
+                    url=self.get_entity_url(context_entity),
                 )
                 self.adobe.send_context_thumbnail(data)
 
@@ -1928,7 +1947,8 @@ class AfterEffectsEngine(sgtk.platform.Engine):
               onclick='sg_panel.Panel.open_external_url("{url}")'
             >{text}</a>
             """.format(
-            url=url, text=text,
+            url=url,
+            text=text,
         )
 
     def __activate_python(self):

--- a/hooks/context_fields_display.py
+++ b/hooks/context_fields_display.py
@@ -179,7 +179,9 @@ class ContextFieldsDisplay(HookBaseClass):
                 <td class='sg_value_td'>{status}</td>
               </tr>
             """.format(
-            name=asset_link, type=entity["sg_asset_type"], status=status,
+            name=asset_link,
+            type=entity["sg_asset_type"],
+            status=status,
         )
 
         # tags if there are any
@@ -231,7 +233,8 @@ class ContextFieldsDisplay(HookBaseClass):
             shot_display = """
                 {name}&nbsp;<span class='sg_label'>({seq_name})</span>
                 """.format(
-                name=shot_link, seq_name=seq_link,
+                name=shot_link,
+                seq_name=seq_link,
             )
 
         # always include name, type, and status
@@ -246,7 +249,8 @@ class ContextFieldsDisplay(HookBaseClass):
                 <td class='sg_value_td'>{status}</td>
               </tr>
             """.format(
-            name=shot_display, status=status,
+            name=shot_display,
+            status=status,
         )
 
         # tags if there are any
@@ -337,7 +341,8 @@ class ContextFieldsDisplay(HookBaseClass):
                 task_display = """
                     {name}&nbsp;<span class='sg_label'>({step_name})</span>
                     """.format(
-                    name=task_display, step_name=step_name,
+                    name=task_display,
+                    step_name=step_name,
                 )
 
         # always include name
@@ -368,7 +373,8 @@ class ContextFieldsDisplay(HookBaseClass):
                     <td class='sg_value_td'>{name}</td>
                   </tr>
                 """.format(
-                entity_type=linked_entity["type"], name=linked_entity_link,
+                entity_type=linked_entity["type"],
+                name=linked_entity_link,
             )
 
         # always show the status
@@ -398,7 +404,8 @@ class ContextFieldsDisplay(HookBaseClass):
                     <td class='sg_value_td'>{name}</td>
                   </tr>
                 """.format(
-                label=assignee_label, name=assignee_display,
+                label=assignee_label,
+                name=assignee_display,
             )
 
         # due date
@@ -433,7 +440,8 @@ class ContextFieldsDisplay(HookBaseClass):
                 <td class='sg_value_td'>{name}</td>
               </tr>
             """.format(
-            entity_type=entity_type, name=entity_link,
+            entity_type=entity_type,
+            name=entity_link,
         )
 
         # show a status if one can be determined

--- a/hooks/tk-multi-publish2/basic/copy_rendering.py
+++ b/hooks/tk-multi-publish2/basic/copy_rendering.py
@@ -361,7 +361,9 @@ class AfterEffectsCopyRenderPlugin(HookBaseClass):
         # in case we will render before publishing we
         # have to check if the templates are matching
         ext_state = self.__template_extension_match_render_paths(
-            render_paths, render_seq_path_template, render_mov_path_template,
+            render_paths,
+            render_seq_path_template,
+            render_mov_path_template,
         )
         if ext_state != self.FULLY_ACCEPTED:
             return ext_state

--- a/startup.py
+++ b/startup.py
@@ -177,7 +177,8 @@ class AfterEffectsLauncher(SoftwareLauncher):
         # we don't want to stomp on any PYTHONPATH that might already exist that
         # we want to persist when the Python subprocess is spawned.
         sgtk.util.append_path_to_env_var(
-            "PYTHONPATH", os.pathsep.join(sys.path),
+            "PYTHONPATH",
+            os.pathsep.join(sys.path),
         )
         env["PYTHONPATH"] = os.environ["PYTHONPATH"]
 

--- a/tests/rpc_tests/basic.py
+++ b/tests/rpc_tests/basic.py
@@ -20,7 +20,11 @@ class TestAdobeRPC(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.resources = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "resources",),
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "resources",
+            ),
         )
 
     def test_simple_eval(self):
@@ -31,11 +35,16 @@ class TestAdobeRPC(unittest.TestCase):
         next_uid = self.adobe._UID + 1
 
         expected_payload = dict(
-            method="foo", id=next_uid, jsonrpc="2.0", params=[1, 2, 3],
+            method="foo",
+            id=next_uid,
+            jsonrpc="2.0",
+            params=[1, 2, 3],
         )
 
         payload = self.adobe._get_payload(
-            method="foo", proxy_object=None, params=[1, 2, 3],
+            method="foo",
+            proxy_object=None,
+            params=[1, 2, 3],
         )
 
         self.assertEqual(expected_payload, payload)
@@ -44,7 +53,12 @@ class TestAdobeRPC(unittest.TestCase):
         expected_response = dict(foo="bar")
         next_uid = self.adobe._UID + 1
 
-        raw_response = json.dumps(dict(id=next_uid, result=expected_response,),)
+        raw_response = json.dumps(
+            dict(
+                id=next_uid,
+                result=expected_response,
+            ),
+        )
 
         self.adobe._handle_response(raw_response)
 


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site