### PR TITLE
Fix window parenting

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -319,6 +319,7 @@ class AfterEffectsEngine(sgtk.platform.Engine):
             return {"name": "AfterFX", "version": "unknown"}
 
         version = self.adobe.app.version
+        cc_version = version
         # app.aftereffects.AfterEffectsVersion just returns 18.1.1 which is not what users see in the UI
         # extract a more meaningful version from the systemInformation property
         # which gives something like:

--- a/engine.py
+++ b/engine.py
@@ -1236,7 +1236,7 @@ class AfterEffectsEngine(sgtk.platform.Engine):
         handle (HWND)
         """
         if not self._WIN32_AFTEREFFECTS_MAIN_HWND:
-            self.logger.debug('Attempting to locate AE window...')
+            self.logger.debug("Attempting to locate AE window...")
             for major in sorted(self.__CC_VERSION_MAPPING.keys()):
                 for minor in range(10):
                     class_name = "AE_CApplication_{}.{}".format(major, minor)


### PR DESCRIPTION
Hello. This PR addresses critical issues with Qt window parenting.

- Add the latest AE version to the CC version mapping.
- Add some debugging around locating the AE window.
- Switch the proxy window title to a uuid instead of a generic string.
  This resulted in more stability in locating the proxy window handle.