### PR TITLE
SG-29554 Properly close the widgets when quitting After Effects

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -265,10 +265,9 @@ class AfterEffectsEngine(sgtk.platform.Engine):
         # that we know about. This will stop memory leaks, and is also prudent
         # since we're severing the socket.io connection that will allow them
         # to function properly.
-        for dialog in self.__qt_dialogs:
-            dialog.hide()
-            dialog.setParent(None)
-            dialog.deleteLater()
+        dialogs_still_opened = self.created_qt_dialogs[:]
+        for dialog in dialogs_still_opened:
+            dialog.close()
 
         # Gracefully stop our data retriever. This call will block until the
         # currently-processing request has completed.


### PR DESCRIPTION
When quitting AE, we notice two unexpected behaviours:
- if a TK widget is opened, it won't be closed and will be in a frozen state after AE exit
- an orphan Python process will still be alive even after AE exit

This PR addresses these two behaviours by:
- Making sure all the opened widgets will be destroyed when AE exits
- The Python process will be killed properly at closing time


Symmetric change copied from tk-photoshopcc: shotgunsoftware/tk-photoshopcc#100