### PR TITLE
SG-42049: Update README badges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ exclude: "ui\/.*py$|docs"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -38,6 +38,6 @@ repos:
 
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
     - id: black

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-aftereffects?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=70&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
 
 ## Documentation
 This repository is a part of the Flow Production Tracking Toolkit.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Adobe After Effects
 
 ![Supported After Effects versions: 2022 (v22) - 2025 (v25)](https://img.shields.io/badge/After_Effects-2022_%28v22%29_--_2025_%28v25%29-blue "Supported After Effects versions")
-[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
+[![Supported VFX Platform: CY2022 - CY2026](https://img.shields.io/badge/VFX_Reference_Platform-CY2022_|_CY2023_|_CY2024_|_CY2025_|_CY2026-blue)](http://www.vfxplatform.com/ "Supported VFX Reference Platform versions")
+[![Supported Python versions: 3.9, 3.10, 3.11, 3.13](https://img.shields.io/badge/Python-3.9_|_3.10_|_3.11_|_3.13-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-aftereffects?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=70&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -1835,17 +1835,13 @@ class AfterEffectsEngine(sgtk.platform.Engine):
             self.__context_find_uid = None
 
             # send an error message back to the context header.
-            self.adobe.send_context_display(
-                """
+            self.adobe.send_context_display("""
                 There was an error retrieving fields for this context. Please
                 see the logs for the specific error message. If this is a
                 recurring error and you need further assistance, please
                 contact our support team via <a href='{url}'>
                 {url}</a>.
-                """.format(
-                    url=sgtk.support_url
-                )
-            )
+                """.format(url=sgtk.support_url))
             self.logger.error("Failed to query context fields: %s" % (msg,))
 
         elif uid == self.__context_thumb_uid:
@@ -1972,9 +1968,7 @@ class AfterEffectsEngine(sgtk.platform.Engine):
                 tell application "System Events"
                   set frontmost of the first process whose unix id is {pid} to true
                 end tell
-                """.format(
-                pid=os.getpid()
-            )
+                """.format(pid=os.getpid())
 
             # force this python process to the front
             cmd = ["osascript", "-e", osx_activate_script]

--- a/hooks/context_fields_display.py
+++ b/hooks/context_fields_display.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
@@ -203,9 +202,7 @@ class ContextFieldsDisplay(HookBaseClass):
                   <td class='sg_label_td'>Desc:</td>
                   <td class='sg_value_td'>{desc}</td>
                 </tr>
-                """.format(
-                desc=entity["description"]
-            )
+                """.format(desc=entity["description"])
 
         # close up the table
         html += "</table>"
@@ -273,9 +270,7 @@ class ContextFieldsDisplay(HookBaseClass):
         if entity["sg_cut_in"] is not None and entity["sg_cut_out"] is not None:
             cut_display = """
                     {cut_in} - {cut_out}
-                """.format(
-                cut_in=entity["sg_cut_in"], cut_out=entity["sg_cut_out"]
-            )
+                """.format(cut_in=entity["sg_cut_in"], cut_out=entity["sg_cut_out"])
 
         # include head/tail if set
         if (
@@ -311,9 +306,7 @@ class ContextFieldsDisplay(HookBaseClass):
                   <td class='sg_label_td'>Desc:</td>
                   <td class='sg_value_td'>{desc}</td>
                 </tr>
-                """.format(
-                desc=entity["description"]
-            )
+                """.format(desc=entity["description"])
 
         # close up the table
         html += "</table>"
@@ -352,9 +345,7 @@ class ContextFieldsDisplay(HookBaseClass):
                 <td class='sg_label_td'>Task:</td>
                 <td class='sg_value_td'>{name}</td>
               </tr>
-            """.format(
-            name=task_display
-        )
+            """.format(name=task_display)
 
         # entity
         if entity["entity"]:
@@ -383,9 +374,7 @@ class ContextFieldsDisplay(HookBaseClass):
                 <td class='sg_label_td'>Status:</td>
                 <td class='sg_value_td'>{status}</td>
               </tr>
-            """.format(
-            status=status
-        )
+            """.format(status=status)
 
         # artist
         if entity["task_assignees"]:
@@ -488,9 +477,7 @@ class ContextFieldsDisplay(HookBaseClass):
                   <td class='sg_label_td'>Desc:</td>
                   <td class='sg_value_td'>{desc}</td>
                 </tr>
-                """.format(
-                desc=desc
-            )
+                """.format(desc=desc)
 
         # close up the table
         html += "</table>"

--- a/hooks/import_footage.py
+++ b/hooks/import_footage.py
@@ -2,7 +2,6 @@ import os
 
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -11,6 +11,7 @@
 """
 Hook that loads defines all the available actions, broken down by publish type.
 """
+
 import os
 import re
 import glob

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -10,7 +10,6 @@
 import os
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-publish2/basic/copy_rendering.py
+++ b/hooks/tk-multi-publish2/basic/copy_rendering.py
@@ -16,7 +16,6 @@ import shutil
 import sgtk
 from sgtk.util.filesystem import ensure_folder_exists
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-publish2/basic/make_rendering.py
+++ b/hooks/tk-multi-publish2/basic/make_rendering.py
@@ -12,7 +12,6 @@ import os
 
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-publish2/basic/publish_document.py
+++ b/hooks/tk-multi-publish2/basic/publish_document.py
@@ -12,7 +12,6 @@ import os
 
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
@@ -81,9 +80,7 @@ class AfterEffectsProjectPublishPlugin(HookBaseClass):
         A file can be published multiple times however only the most recent
         publish will be available to other users. Warnings will be provided
         during validation if there are previous publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):
@@ -241,13 +238,13 @@ class AfterEffectsProjectPublishPlugin(HookBaseClass):
         # check to see if the next version of the work file already exists on
         # disk. if so, warn the user and provide the ability to jump to save
         # to that version now
-        (next_version_path, version) = self._get_next_version_info(path, item)
+        next_version_path, version = self._get_next_version_info(path, item)
         if next_version_path and os.path.exists(next_version_path):
 
             # determine the next available version_number. just keep asking for
             # the next one until we get one that doesn't exist.
             while os.path.exists(next_version_path):
-                (next_version_path, version) = self._get_next_version_info(
+                next_version_path, version = self._get_next_version_info(
                     next_version_path, item
                 )
 

--- a/hooks/tk-multi-publish2/basic/publish_rendering.py
+++ b/hooks/tk-multi-publish2/basic/publish_rendering.py
@@ -12,7 +12,6 @@ import re
 
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
@@ -50,9 +49,7 @@ class AfterEffectsRenderPublishPlugin(HookBaseClass):
         A file can be published multiple times however only the most recent
         publish will be available to other users. Warnings will be provided
         during validation if there are previous publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):

--- a/hooks/tk-multi-publish2/basic/start_version_control.py
+++ b/hooks/tk-multi-publish2/basic/start_version_control.py
@@ -12,7 +12,6 @@ import os
 
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-publish2/basic/upload_project_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_project_version.py
@@ -12,7 +12,6 @@ import os
 
 import sgtk
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
+++ b/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
@@ -11,6 +11,7 @@
 """
 Hook that loads defines all the available actions, broken down by publish type.
 """
+
 import re
 import glob
 import os

--- a/hooks/tk-multi-workfiles2/basic/scene_operation.py
+++ b/hooks/tk-multi-workfiles2/basic/scene_operation.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import sgtk
 
-
 HookClass = sgtk.get_hook_baseclass()
 
 

--- a/python/tk_aftereffects/__init__.py
+++ b/python/tk_aftereffects/__init__.py
@@ -11,7 +11,6 @@
 import sys
 import sgtk
 
-
 adobe_bridge = sgtk.platform.import_framework(
     "tk-framework-adobe", "tk_framework_adobe.adobe_bridge"
 )


### PR DESCRIPTION
Updates README badges:
- Removed deprecated HoundCI badge
- Updated VFX Platform to include CY2026 support
- Updated Python versions to include 3.13
- Updated pre-commit hooks (v5.0.0 → v6.0.0, black 25.1.0 → 26.1.0)
- Fixed black formatting (14 files reformatted)


Related SG-42049 PRs:
- shotgunsoftware/tk-aftereffects#63
- shotgunsoftware/tk-core#1084
- shotgunsoftware/tk-framework-desktopclient#36
- shotgunsoftware/tk-framework-qtwidgets#181
- shotgunsoftware/tk-framework-shotgunutils#177
- shotgunsoftware/tk-framework-widget#31
- shotgunsoftware/tk-multi-about#36
- shotgunsoftware/tk-multi-breakdown#45
- shotgunsoftware/tk-multi-demo#48
- shotgunsoftware/tk-multi-launchapp#111
- shotgunsoftware/tk-multi-loader2#135
- shotgunsoftware/tk-multi-publish2#211
- shotgunsoftware/tk-multi-pythonconsole#44
- shotgunsoftware/tk-multi-reviewsubmission#51
- shotgunsoftware/tk-multi-screeningroom#26
- shotgunsoftware/tk-multi-snapshot#50
- shotgunsoftware/tk-multi-workfiles2#170
- shotgunsoftware/tk-shell#38